### PR TITLE
Disable context menu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ make test
 ```
 or:
 ```
-nosetests tests
+python3 -m nose tests
 ```
 
 Single tests can be run like this:
 ```
-nosetests tests/<file_name>.py:<class_name>:<method_name>
+python3 -m nose tests/<file_name>.py:<class_name>:<method_name>
 ```
 
 Nose captures `stdout` by default.
@@ -160,7 +160,7 @@ Use the `-s` switch if you want to print output during the test run.
 
 You can increase the verbosity level with the `-v` switch.
 
-Add --pdb to the command line to automatically drop into the debugger on errors and failures.
+Add `--pdb` to the command line to automatically drop into the debugger on errors and failures.
 If you want to drop into the debugger before a failure, edit the test and add the following code at the exact spot where you want the debugger to be started:
 ```
 from nose.tools import set_trace; set_trace()
@@ -177,7 +177,7 @@ Then, run the following command from within the top-level directory of the repos
 sudo python setup.py install
 ```
 
-To test the installation, change to any other directory and run `menmosyne`.
+To test the installation, change to any other directory and run `mnemosyne`.
 For example:
 ```
 cd ~

--- a/mnemosyne/pyqt_ui/review_wdgt.py
+++ b/mnemosyne/pyqt_ui/review_wdgt.py
@@ -271,7 +271,8 @@ class ReviewWdgt(QtWidgets.QWidget, QAOptimalSplit, ReviewWidget, Ui_ReviewWdgt)
         self.setupUi(self)
         QAOptimalSplit.setup(self)
 
-        # TODO: move this to designer with update of PyQt.
+        # TODO: Move this to designer, once QButtonGroup elements can be set
+        # to custom ID from designer.
         self.grade_buttons = QtWidgets.QButtonGroup()
         self.grade_buttons.addButton(self.grade_0_button, 0)
         self.grade_buttons.addButton(self.grade_1_button, 1)

--- a/mnemosyne/pyqt_ui/review_wdgt.ui
+++ b/mnemosyne/pyqt_ui/review_wdgt.ui
@@ -200,7 +200,7 @@
   </customwidget>
   <customwidget>
    <class>QPushButton2</class>
-   <extends>QWidget</extends>
+   <extends>QPushButton</extends>
    <header>mnemosyne/pyqt_ui/qpushbutton2</header>
   </customwidget>
  </customwidgets>

--- a/mnemosyne/pyqt_ui/review_wdgt.ui
+++ b/mnemosyne/pyqt_ui/review_wdgt.ui
@@ -66,6 +66,9 @@
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
          </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::NoContextMenu</enum>
+         </property>
          <property name="acceptDrops">
           <bool>false</bool>
          </property>
@@ -103,6 +106,9 @@
          </property>
          <property name="focusPolicy">
           <enum>Qt::StrongFocus</enum>
+         </property>
+         <property name="contextMenuPolicy">
+          <enum>Qt::NoContextMenu</enum>
          </property>
          <property name="acceptDrops">
           <bool>false</bool>


### PR DESCRIPTION
- Disables the context menu in the review widget.
- I got sidetracked: tiny change to `review_wdgt.ui` that promotes the buttons correctly so they are displayed in the designer. Not sure if this is worth the change.

It is in general possible to create your own context menu (see [here](https://github.com/three-comrades/mnemosyne/commit/601aa1fe1f66a841aba5d98af8a14f3c5d2a4ac1)), but I totally missed that `ctrl+e` already let's me edit the current card. I don't think it makes much sense to replicate that in the context menu, so for now let's just disable it completely.

Edit: oops, had to rebase on master.