### PR TITLE
pillow -> Pillow

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To start working on Mnemosyne, you need at least the following software.
 - [Easyinstall](http://peak.telecommunity.com/DevCenter/EasyInstall)
 - [cheroot](https://pypi.python.org/pypi/Cheroot/) 5 or later
 - [Webob](http://webob.org) 1.4 or later
-- [pillow](http://python-pillow.org)
+- [Pillow](http://python-pillow.org)
 - For Latex support: the `latex` and `dvipng` commands must be available (e.g., `TeXLive` on Linux, `MacTeX` on Mac, and `MikTeX` on Windows).
 - For building the docs: [sphinx](http://sphinx-doc.org)
 - For running the tests: [nose](https://nose.readthedocs.io/en/latest/)


### PR DESCRIPTION
pillow is strongly capitalized, including in name typed on command line
for example 'pip install Pillow' accordig to http://pillow.readthedocs.io/en/3.0.x/installation.html
and in what pip list displays