### PR TITLE
Remove the non-portable settings buildDir from build.gradle

### DIFF
--- a/mnemosyne/android/build.gradle
+++ b/mnemosyne/android/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 }
 
 allprojects {
-    buildDir = "C:/tmp/${rootProject.name}/${project.name}"
     repositories {
         jcenter()
         google()


### PR DESCRIPTION
Such settings should be set in local.properties and not committed to the git repo.
Fixes #84.

Please merge #91 first so that #84 can actually be marked as fixed ;)