### PR TITLE
Remove debugging print statement from tsv import code

### DIFF
--- a/mnemosyne/libmnemosyne/file_formats/tsv.py
+++ b/mnemosyne/libmnemosyne/file_formats/tsv.py
@@ -86,7 +86,6 @@ class Tsv(FileFormat, MediaPreprocessor):
             else:
                 card_type = self.card_type_with_id("3")
             self.preprocess_media(fact_data, tag_names)
-            print(fact_data)
             self.controller().create_new_cards(fact_data, card_type, grade=-1,
                 tag_names=tag_names, check_for_duplicates=False, save=False)
             if _("MISSING_MEDIA") in tag_names:


### PR DESCRIPTION
This fixes an issues that causes UTF-8 characters in TSV files on macOS
to fail the import process

Issue report at
https://groups.google.com/d/msgid/mnemosyne-proj-users/3930acc4-c703-4944-852a-fcc6fdcb1339%40googlegroups.com