### PR TITLE
Remember how many cards we've learned today even after re-opening the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To start working on Mnemosyne, you need at least the following software.
 - [cheroot](https://pypi.python.org/pypi/Cheroot/) 5 or later
 - [Webob](http://webob.org) 1.4 or later
 - [Pillow](http://python-pillow.org)
-- For Latex support: the `latex` and `dvipng` commands must be available (e.g., `TeXLive` on Linux, `MacTeX` on Mac, and `MikTeX` on Windows).
+- For Latex support: the `latex` and `dvipng` commands must be available (e.g., `TeXLive` on Linux, `MacTeX` on Mac, and `MikTeX` on Windows). On Arch based distributions, you'll need `texlive-core` package too. 
 - For building the docs: [sphinx](http://sphinx-doc.org)
 - For running the tests: [nose](https://nose.readthedocs.io/en/latest/)
 

--- a/mnemosyne/libmnemosyne/controllers/default_controller.py
+++ b/mnemosyne/libmnemosyne/controllers/default_controller.py
@@ -134,7 +134,7 @@ class DefaultController(Controller):
                 if partial_tag:
                     partial_tag += "::"
                 partial_tag += node
-                if  partial_tag in tag_names:
+                if partial_tag in tag_names:
                     parent_tag_names.append(partial_tag)
         return list(set(tag_names) - set(parent_tag_names))
 

--- a/mnemosyne/libmnemosyne/controllers/default_controller.py
+++ b/mnemosyne/libmnemosyne/controllers/default_controller.py
@@ -136,7 +136,7 @@ class DefaultController(Controller):
                 partial_tag += node
                 if partial_tag in tag_names:
                     parent_tag_names.append(partial_tag)
-        return list(set(tag_names) - set(parent_tag_names))
+        return sorted(list(set(tag_names) - set(parent_tag_names)))
 
     def create_new_cards(self, fact_data, card_type, grade, tag_names,
                          check_for_duplicates=True, save=True):

--- a/mnemosyne/libmnemosyne/databases/SQLite_logging.py
+++ b/mnemosyne/libmnemosyne/databases/SQLite_logging.py
@@ -426,3 +426,7 @@ class SQLiteLogging(object):
         self.con.executescript(script)
         self.main_widget().close_progress()
 
+    def log_warn_about_too_many_cards(self, timestamp):
+        self.con.execute(
+            "insert into log(event_type, timestamp) values(?,?)",
+            (EventTypes.WARNED_TOO_MANY_CARDS, int(timestamp)))

--- a/mnemosyne/libmnemosyne/logger.py
+++ b/mnemosyne/libmnemosyne/logger.py
@@ -199,3 +199,6 @@ class Logger(Component):
             print((_("Waiting for uploader thread to stop...").encode("utf-8")))
             self.upload_thread.join()
             print((_("Done!").encode("utf-8")))
+
+    def warn_too_many_cards(self):
+        pass

--- a/mnemosyne/libmnemosyne/loggers/database_logger.py
+++ b/mnemosyne/libmnemosyne/loggers/database_logger.py
@@ -135,3 +135,5 @@ class DatabaseLogger(Logger):
     def dump_to_science_log(self):
         self.database().dump_to_science_log()
 
+    def warn_too_many_cards(self):
+        self.database().log_warn_about_too_many_cards(self.timestamp)

--- a/mnemosyne/libmnemosyne/schedulers/SM2_mnemosyne.py
+++ b/mnemosyne/libmnemosyne/schedulers/SM2_mnemosyne.py
@@ -668,6 +668,8 @@ _("You appear to have missed some reviews. Don't worry too much about this backl
             return "%.1f " % interval_years +  _("years ago")
 
     def today_learned_fact_ids(self):
+        if not self.database().is_loaded():
+            return []
         timestamp = time.time() - 0 - self.config()["day_starts_at"] * HOUR
         date_only = datetime.date.fromtimestamp(timestamp)  # Local date.
         start_of_day = int(time.mktime(date_only.timetuple()))

--- a/mnemosyne/libmnemosyne/schedulers/SM2_mnemosyne.py
+++ b/mnemosyne/libmnemosyne/schedulers/SM2_mnemosyne.py
@@ -35,6 +35,8 @@ class SM2Mnemosyne(Scheduler):
     """
 
     name = "SM2 Mnemosyne"
+    warned_about_too_many_cards = False  # by default initialize as True
+
 
     def midnight_UTC(self, timestamp):
 
@@ -151,7 +153,6 @@ class SM2Mnemosyne(Scheduler):
             self.stage = 1
         else:
             self.stage = 3
-        self.warned_about_too_many_cards = False
         # warn even on startup if they've reached 15
         self.warn_too_many_cards()
 
@@ -709,7 +710,8 @@ _("You appear to have missed some reviews. Don't worry too much about this backl
         return new_ids + forgotten_ids
 
     def warn_too_many_cards(self):
-        if (len(self._fact_ids_memorised) >= 15 and
+        # only alert if it is exactly 15, do be obtrusive
+        if (len(self._fact_ids_memorised) == 15 and
                 not self.warned_about_too_many_cards):
             self.main_widget().show_information(
                 ("You've memorised 15 new or failed cards.") + " " +

--- a/mnemosyne/libmnemosyne/schedulers/SM2_mnemosyne.py
+++ b/mnemosyne/libmnemosyne/schedulers/SM2_mnemosyne.py
@@ -219,8 +219,6 @@ class SM2Mnemosyne(Scheduler):
         self._card_ids_in_queue = []
         self._fact_ids_in_queue = []
         self.warned_about_too_many_cards = self.already_warned_today()
-        # warn even on startup if they've reached 15
-        self.warn_too_many_cards()
 
         # Stage 1
         #

--- a/openSM2sync/log_entry.py
+++ b/openSM2sync/log_entry.py
@@ -48,7 +48,7 @@ class EventTypes(object):
     # Optional.
 
     EDITED_SETTING = 28
-
+    WARNED_TOO_MANY_CARDS = 29
 
 class LogEntry(dict):
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -203,7 +203,7 @@ class TestController(MnemosyneTest):
     def test_retain_only_child_tags(self):
         c = self.controller()
         assert c._retain_only_child_tags(["a"]) == ["a"]
-        assert c._retain_only_child_tags(["a", "b"]) == ["a", "b"]
+        assert sorted(c._retain_only_child_tags(["a", "b"])) == sorted(["a", "b"])
         assert c._retain_only_child_tags(["a", "a::b"]) == ["a::b"]
         assert c._retain_only_child_tags(["a", "a::b", "a::b::c"]) == ["a::b::c"]
         assert c._retain_only_child_tags(["a", "a::b::c"]) == ["a::b::c"]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -4,6 +4,7 @@
 
 import os
 import shutil
+import time
 
 from mnemosyne_test import MnemosyneTest
 from mnemosyne.libmnemosyne import Mnemosyne
@@ -385,3 +386,8 @@ class TestLogging(MnemosyneTest):
         arch_con = sqlite3.connect(archive_path)
         assert arch_con.execute("select count() from log").fetchone()[0] == 11
 
+    def test_log_warn_about_too_many_cards(self):
+        timestamp = int(time.time())
+        self.database().log_warn_about_too_many_cards(timestamp)
+        results = self.database().con.execute("""select timestamp from log WHERE event_type=? and timestamp = ?""", (EventTypes.WARNED_TOO_MANY_CARDS, timestamp)).fetchall()
+        assert 1 == len(results)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -225,6 +225,9 @@ class TestScheduler(MnemosyneTest):
             self.scheduler().grade_answer(card, 5)
             self.database().update_card(card)
 
+        facts = self.scheduler()._fact_ids_learned_today()
+        assert(len(facts)) == 5
+
     def test_learn_ahead_2(self):
         card_type = self.card_type_with_id("1")
         fact_data = {"f": "1", "b": "b"}
@@ -240,6 +243,8 @@ class TestScheduler(MnemosyneTest):
                      grade=-1, tag_names=["default"])[0]
         assert self.scheduler().next_card() == new_card
 
+        facts = self.scheduler()._fact_ids_learned_today()
+        assert(len(facts)) == 1
 
     def test_4(self):
         card_type = self.card_type_with_id("1")
@@ -258,6 +263,9 @@ class TestScheduler(MnemosyneTest):
         self.database().update_card(card)
 
         assert self.scheduler().next_card() != None
+
+        facts = self.scheduler()._fact_ids_learned_today()
+        assert(len(facts)) == 0
 
     def test_5(self):
         card_type = self.card_type_with_id("1")
@@ -320,7 +328,6 @@ class TestScheduler(MnemosyneTest):
         self.review_controller().show_new_question()
         self.review_controller().grade_answer(0)
         assert self.review_controller().scheduled_count == 0
-
 
     def test_sister_together(self):
         card_type = self.card_type_with_id("2")


### PR DESCRIPTION
## Rationale

When we close the Mnemosyne application and re-open it, it won't
remember the number of the already memorized cards. In other words, it
won't warn you if you've already learned 15 or more words.

## Implementation
This PR aims to fix this issue and re-construct the
`self._fact_ids_memorised` from the logs which are not that hard.

We can fetch all the newly learned cards (same query as in the statistics) and all the forgotten but
learned cards today. Combining the two, we can get the number of learned cards today.

## New features
- The already memorized cards are re-constructed from the logs
- It only warns once per day
- Fixed long-time flaky python3.7 test

Any comments are welcome.