### PR TITLE
Enable Retina support on macOS

### DIFF
--- a/darwin/Info.plist
+++ b/darwin/Info.plist
@@ -22,5 +22,7 @@
 	<true/>
 	<key>LSBackgroundOnly</key>
 	<string>0</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
 </dict>
 </plist>

--- a/mnemosyne.spec
+++ b/mnemosyne.spec
@@ -264,4 +264,7 @@ if sys.platform == "darwin":
   app = BUNDLE(coll,
                name='Mnemosyne.app',
                icon=os.path.join('pixmaps', 'mnemosyne.icns'),
+info_plist={
+            'NSHighResolutionCapable': 'True'
+            },
                bundle_identifier='org.qt-project.Qt.QtWebEngineCore')

--- a/mnemosyne.spec
+++ b/mnemosyne.spec
@@ -264,7 +264,5 @@ if sys.platform == "darwin":
   app = BUNDLE(coll,
                name='Mnemosyne.app',
                icon=os.path.join('pixmaps', 'mnemosyne.icns'),
-info_plist={
-            'NSHighResolutionCapable': 'True'
-            },
+               info_plist={'NSHighResolutionCapable': 'True'},
                bundle_identifier='org.qt-project.Qt.QtWebEngineCore')

--- a/mnemosyne/libmnemosyne/configuration.py
+++ b/mnemosyne/libmnemosyne/configuration.py
@@ -460,6 +460,9 @@ class Configuration(Component, dict):
         # use the default OS language settings is possible
         # getdefaultlocale is OS independent and works on all platforms
         system_language, _ = getdefaultlocale()
+        # if no default locale can be found, default to English
+        if system_language is None:
+            system_language = 'en_us'
         lang_code = system_language.split("_")[0]
 
         # special case ca@valencia, we only support this specific one


### PR DESCRIPTION
Only the `info.plist` file had to be changed to enable Retina support.