### PR TITLE
Move midnight_UTC from SM2 to base Scheduler

### DIFF
--- a/mnemosyne/libmnemosyne/file_formats/mnemosyne1.py
+++ b/mnemosyne/libmnemosyne/file_formats/mnemosyne1.py
@@ -4,8 +4,6 @@
 #
 
 import re
-import datetime
-import calendar
 
 from mnemosyne.libmnemosyne.gui_translator import _
 from mnemosyne.libmnemosyne.utils import MnemosyneError
@@ -155,13 +153,6 @@ class Mnemosyne1(MediaPreprocessor):
             self.set_card_attributes\
                 (card_2, self.items_by_id[item.id + ".tr.1"])
 
-    def midnight_UTC(self, timestamp):
-        try:
-            date_only = datetime.date.fromtimestamp(timestamp)
-        except ValueError:
-            date_only = datetime.date.max
-        return int(calendar.timegm(date_only.timetuple()))
-
     def set_card_attributes(self, card, item):
         # Note that we cannot give cards a new id, otherwise the log server
         # would not know it was the same card.
@@ -171,9 +162,9 @@ class Mnemosyne1(MediaPreprocessor):
             setattr(card, attr, getattr(item, attr))
         DAY = 24 * 60 * 60 # Seconds in a day.
         card.last_rep = \
-            self.midnight_UTC(self.starttime + item.last_rep * DAY)
+            self.scheduler().midnight_UTC(self.starttime + item.last_rep * DAY)
         card.next_rep = \
-            self.midnight_UTC(self.starttime + item.next_rep * DAY)
+            self.scheduler().midnight_UTC(self.starttime + item.next_rep * DAY)
         if not hasattr(item, "unseen"):
             item.unseen = True
         if item.unseen and item.grade in [0, 1]:

--- a/mnemosyne/libmnemosyne/scheduler.py
+++ b/mnemosyne/libmnemosyne/scheduler.py
@@ -2,6 +2,9 @@
 # scheduler.py <Peter.Bienstman@UGent.be>
 #
 
+import calendar
+import datetime
+
 from mnemosyne.libmnemosyne.component import Component
 
 
@@ -124,3 +127,31 @@ class Scheduler(Component):
         """
 
         raise NotImplementedError
+
+    def midnight_UTC(self, timestamp):
+
+        """Round a timestamp to a value with resolution of a day, storing it
+        in a timezone independent way, as a POSIX timestamp corresponding to
+        midnight UTC on that date.
+
+        E.g. if the scheduler sets 'next_rep' to 2012/1/1 12:14 local time,
+        this function will return the timestamp corresponding to
+        2012/1/1 00;00 UTC.
+
+        Important: the timestamp needs to have the meaning of local time,
+        not e.g. UTC, so calling midnight_UTC twice will give unexpected
+        results.
+
+        """
+
+        # Create a time tuple containing the local date only, i.e. throwing
+        # away hours, minutes, etc.
+        # Android/Crystax 10.3.2 actually has a 2038 overflow problem...
+        try:
+            date_only = datetime.date.fromtimestamp(timestamp).timetuple()
+        except OverflowError:
+            date_only = datetime.date.fromtimestamp(2**31-2).timetuple()
+        # Now we reinterpret this same time tuple as being UTC and convert it
+        # to a POSIX timestamp. (Note that timetuples are 'naive', i.e. they
+        # themselves do not contain timezone information.)
+        return int(calendar.timegm(date_only))

--- a/mnemosyne/libmnemosyne/schedulers/SM2_mnemosyne.py
+++ b/mnemosyne/libmnemosyne/schedulers/SM2_mnemosyne.py
@@ -4,7 +4,6 @@
 
 import time
 import random
-import calendar
 import datetime
 
 from mnemosyne.libmnemosyne.gui_translator import _
@@ -35,34 +34,6 @@ class SM2Mnemosyne(Scheduler):
 
     name = "SM2 Mnemosyne"
     warned_about_too_many_cards = False  # default false
-
-    def midnight_UTC(self, timestamp):
-
-        """Round a timestamp to a value with resolution of a day, storing it
-        in a timezone independent way, as a POSIX timestamp corresponding to
-        midnight UTC on that date.
-
-        E.g. if the scheduler sets 'next_rep' to 2012/1/1 12:14 local time,
-        this function will return the timestamp corresponding to
-        2012/1/1 00;00 UTC.
-
-        Important: the timestamp needs to have the meaning of local time,
-        not e.g. UTC, so calling midnight_UTC twice will give unexpected
-        results.
-
-        """
-
-        # Create a time tuple containing the local date only, i.e. throwing
-        # away hours, minutes, etc.
-        # Android/Crystax 10.3.2 actually has a 2038 overflow problem...
-        try:
-            date_only = datetime.date.fromtimestamp(timestamp).timetuple()
-        except OverflowError:
-            date_only = datetime.date.fromtimestamp(2**31-2).timetuple()
-        # Now we reinterpret this same time tuple as being UTC and convert it
-        # to a POSIX timestamp. (Note that timetuples are 'naive', i.e. they
-        # themselves do not contain timezone information.)
-        return int(calendar.timegm(date_only))
 
     def adjusted_now(self, now=None):
 


### PR DESCRIPTION
Move midnight_UTC from SM2 to base Scheduler since it is
not specific to SM2, and remove the redundant midnight_UTC
implementation elsewhere

(This is partly to test the waters for future patches to
move some non-SM2 specific bits into the base Scheduler
class, like the interval_string functions)