### PR TITLE
Exit app on ctrl-c

### DIFF
--- a/mnemosyne/libmnemosyne/__init__.py
+++ b/mnemosyne/libmnemosyne/__init__.py
@@ -379,7 +379,10 @@ class Mnemosyne(Component):
         try:
             if sys.platform != "win32":
                 sys.stderr.write(body)
-            self.main_widget().show_error(body)
+            if type is KeyboardInterrupt:
+                self.main_widget().handle_keyboard_interrupt(body)
+            else:
+                self.main_widget().show_error(body)
         except:
             sys.stderr.write(body)
 

--- a/mnemosyne/libmnemosyne/ui_components/main_widget.py
+++ b/mnemosyne/libmnemosyne/ui_components/main_widget.py
@@ -34,6 +34,9 @@ class MainWidget(UiComponent):
     def show_error(self, text):
         print(text)
 
+    def handle_keyboard_interrupt(self, text):
+        self.show_error(text)
+
     def default_font_size(self):
         return 12
 

--- a/mnemosyne/pyqt_ui/main_wdgt.py
+++ b/mnemosyne/pyqt_ui/main_wdgt.py
@@ -112,6 +112,10 @@ class MainWdgt(QtWidgets.QMainWindow, MainWidget, Ui_MainWdgt):
     def show_error(self, text):
         QtWidgets.QMessageBox.critical(self.top_window(), _("Mnemosyne"), text)
 
+    def handle_keyboard_interrupt(self, text):
+        self._store_state()
+        QtWidgets.QApplication.exit()
+
     def default_font_size(self):
         return QtWidgets.qApp.font().pointSize()
 


### PR DESCRIPTION
Presently, ctrl-c/KeyboardInterrupt will print an uncaught exception
dialog, which seems suboptimal.

In the excepthook, call a new public MainWidget API,
handle_keyboard_interrupt. Make the QT frontend exit the app in this
case after saving state