### PR TITLE
Fix qprocess warnings

### DIFF
--- a/mnemosyne/pyqt_ui/review_wdgt.py
+++ b/mnemosyne/pyqt_ui/review_wdgt.py
@@ -528,7 +528,7 @@ class ReviewWdgt(QtWidgets.QWidget, QAOptimalSplit, ReviewWidget, Ui_ReviewWdgt)
             self.play_next_file()
 
     def stop_media(self):
-        if self.mplayer is not None:
+        if self.mplayer and self.mplayer.state() == QtCore.QProcess.Running:
             self.mplayer.write(b"quit\n");
         self.media_queue = []
 


### PR DESCRIPTION
On the linux console, mnemosyne repeatedly prints:

  QIODevice::read (QProcess): device not open

This is due to trying to interact with the 'mplayer' process
regardless of whether it's running or not. Check the process state
before trying to interact with it.

I don't have any flashcards that use the mplayer integration, so
I didn't test that this doesn't cause any unwanted issues