### PR TITLE
fix section linking that I broke

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you are interested in running and changing the latest code, please read on.
 We use the git version control system and [Github](https://www.github.com) to coordinate the development.
 Please use a search engine to find out how to install git on your operating system.
 If you are new to git and github, there are many tutorials available on the web.
-For example, [this](https://try.github.io/) interactive tutorial. See also section [working locally with the code](#Working locally with the code) and [sharing your changes](#Sharing your changes) for some info about git and Github.
+For example, [this](https://try.github.io/) interactive tutorial. See also section [working locally with the code](#Working-locally-with-the-code) and [sharing your changes](#Sharing-your-changes) for some info about git and Github.
 
 ## About the code base
 To get an overview of how all the different bits of the library fit together, see the documentation in the code at `mnemosyne/libmnemosyne/docs/build/html/index.html`.


### PR DESCRIPTION
were working in retext, I failed to check whatever Github accepts them

Sorry for not checking properly, this time I looked at https://github.com/matkoniecz/mnemosyne/blob/5ffa207f1239392f614fd2d9a184e168c35b0f33/README.md#installation-of-the-development-version-and-hacking