### PR TITLE
more reliable way to retrieve LaTeX path for macOS

### DIFF
--- a/mnemosyne/libmnemosyne/configuration.py
+++ b/mnemosyne/libmnemosyne/configuration.py
@@ -12,7 +12,6 @@ import importlib
 import textwrap
 from locale import getdefaultlocale
 
-
 from mnemosyne.libmnemosyne.gui_translator import _
 from mnemosyne.libmnemosyne.component import Component
 from mnemosyne.libmnemosyne.schedulers.cramming import RANDOM
@@ -24,7 +23,7 @@ DAY = 24 * HOUR # Seconds in a day.
 re_long_int = re.compile(r"\d+L")
 
 def config_py():
-  config_py = textwrap.dedent(
+  return textwrap.dedent(
   """  # Mnemosyne configuration file.
 
   # This file contains settings which we deem to be too specialised to be
@@ -77,16 +76,6 @@ def config_py():
   # Latex dvipng command.
   dvipng = "dvipng -D 200 -T tight tmp.dvi"
   """)
-
-  if sys.platform == "darwin":
-    # We could use format strings, but the LaTeX has too many { } characters
-    config_py = config_py.replace(
-        'latex = "latex -interaction=nonstopmode"',
-        'latex = "/usr/local/bin/latex -output-format=dvi -interaction=nonstopmode"')
-    config_py = config_py.replace(
-        'dvipng = "dvipng -D 200 -T tight tmp.dvi"',
-        'dvipng = "/usr/local/bin/dvipng -D 200 -T tight tmp.dvi"')
-  return config_py
 
 class Configuration(Component, dict):
 

--- a/mnemosyne/libmnemosyne/filters/latex.py
+++ b/mnemosyne/libmnemosyne/filters/latex.py
@@ -5,6 +5,7 @@
 import os
 import re
 import subprocess as sp
+import sys
 try:
     from hashlib import md5
 except ImportError:
@@ -15,6 +16,9 @@ from mnemosyne.libmnemosyne.utils import copy
 from mnemosyne.libmnemosyne.gui_translator import _
 from mnemosyne.libmnemosyne.filter import Filter
 
+if sys.platform == "darwin":
+  sys.path.append("/usr/local/bin")
+  sys.path.append("/Library/TeX/texbin")
 
 # The regular expressions to find the latex tags are global so they don't
 # get recompiled all the time. match.group(1) identifies the text between
@@ -24,7 +28,6 @@ from mnemosyne.libmnemosyne.filter import Filter
 re1 = re.compile(r"<latex>(.+?)</latex>", re.DOTALL | re.IGNORECASE)
 re2 = re.compile(r"<\$>(.+?)</\$>",       re.DOTALL | re.IGNORECASE)
 re3 = re.compile(r"<\$\$>(.+?)</\$\$>",   re.DOTALL | re.IGNORECASE)
-
 
 class Latex(Filter):
 


### PR DESCRIPTION
This approach makes config.py behave the same as Windows/Linux, but adds the two known paths for LaTeX that I've seen users use to the path manually. That means either approach will work out of the box