### PR TITLE
Force lf line ending for the executable.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 *.mem binary
 tests/files/basedir_bz2/config binary
 tests/files/basedir_sch/config binary
+mnemosyne/pyqt_ui/mnemosyne text eol=lf


### PR DESCRIPTION
Follow-up on #174 

This does two things:
- A fresh check out of this repository will always result in `\n` line endings for `mnemosyne/pyqt_ui/mnemosyne` locally - even on Windows.
- The file will always be committed with `\n` line endings.

But if you change the line endings in your local file, they won't be changed back. I don't think it's possible to enforce this. It just will always normalize the line endings in the file when committing/saving.