### PR TITLE
Fix No attribute `release_database_after_timeout`

### DIFF
--- a/mnemosyne/web_server/web_server.py
+++ b/mnemosyne/web_server/web_server.py
@@ -152,7 +152,8 @@ class WebServer(Component):
         # Load database if needed.
         if not self.is_mnemosyne_loaded and filename != "/release_database":
             self.load_mnemosyne()
-        self.release_database_after_timeout.ping()
+        if self.is_mnemosyne_loaded:
+            self.release_database_after_timeout.ping()
         # All our request return to the root page, so if the path is '/',
         # return the html of the review widget.
         if filename == "/":


### PR DESCRIPTION
Do not access ReleaseDatabaseAfterTimeout if the database is not loaded.

# Description

When both the web-server and sync server are started, the database
might not be loaded because it operates on the "release_database".

```python
# Load database if needed.
if not self.is_mnemosyne_loaded and filename != "/release_database":
    self.load_mnemosyne()
self.release_database_after_timeout.ping()
    #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ is not defined if filename = "/release_database"
```

# Error trace

    AttributeError("'WebServerThread' object has no attribute 'release_database_after_timeout'")
    Traceback (most recent call last):
      File "/usr/local/lib/python3.8/site-packages/cheroot/server.py", line 1280, in communicate
        req.respond()
      File "/usr/local/lib/python3.8/site-packages/cheroot/server.py", line 1083, in respond
        self.server.gateway(self).respond()
      File "/usr/local/lib/python3.8/site-packages/cheroot/wsgi.py", line 143, in respond
        response = self.req.server.wsgi_app(self.env, self.start_response)
      File "/usr/local/lib/python3.8/site-packages/mnemosyne/web_server/web_server.py", line 155, in wsgi_app
        self.release_database_after_timeout.ping()
    AttributeError: 'WebServerThread' object has no attribute 'release_database_after_timeout'

# Steps to reproduce:

1. Start mnemosyne with both web-server and sync-server:

    mnemosyne --web-server --sync-server -d ~/mnemosyne-serv

2. Start mnemosyne as a client

    mnemosyne -d mnemosyne-client

3. Sync the database