### PR TITLE
Associate Mnemosyne with its desktop entry

### DIFF
--- a/mnemosyne/pyqt_ui/mnemosyne
+++ b/mnemosyne/pyqt_ui/mnemosyne
@@ -173,6 +173,7 @@ if options.qt_opengl:
 
 a = QApplication(sys.argv)
 a.setApplicationName("Mnemosyne")
+a.setDesktopFileName("mnemosyne.desktop")
 
 # Add other components we need. The translator should come first.
 # The UI components should come in the order they should be instantiated,


### PR DESCRIPTION
This allows window managers to figure out to which desktop entry the Mnemosyne process belongs. I’ve found this to be necessary for the application name and icon to be displayed correctly in some places on Wayland. I guess it’s because Mnemosyne is running in the python interpreter rather than its own executable.

Before:

![Screenshot_20210613_165552](https://user-images.githubusercontent.com/2063777/121812918-26885280-cc6a-11eb-8263-11d1e5f8346b.png)

After:

![Screenshot_20210613_165659](https://user-images.githubusercontent.com/2063777/121812983-62231c80-cc6a-11eb-996f-8b2d59fa985c.png)