### PR TITLE
Sync password handling enhancements

### DIFF
--- a/README
+++ b/README
@@ -11,6 +11,7 @@ Install the following dependencies if needed:
 - gTTS for Google text-to-speech (https://pypi.org/project/gTTS/)
 - googletrans for Google translate support
   (https://pypi.org/project/googletrans/) 3.0 or later.
+- argon2-cffi (https://pypi.org/project/argon2-cffi/)
 - For Latex support: the latex and dvipng commands must be available
   (e.g. TeXLive)
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To start working on Mnemosyne, you need at least the following software.
 - [Pillow](http://python-pillow.org)
 - [gTTS](https://pypi.org/project/gTTS/) for Google text-to-speech
 - [googletrans](https://pypi.org/project/googletrans/) for Google translate support
+- [argon2-cffi](https://pypi.org/project/argon2-cffi/)
 - For Latex support: the `latex` and `dvipng` commands must be available (e.g., `TeXLive` on Linux, `MacTeX` on Mac, and `MikTeX` on Windows).  On Arch based distributions, you'll need `texlive-core` package too.
 - For building the docs: [sphinx](http://sphinx-doc.org) (If you get sphinx-related errors, try installing sphinx as root)
 - For running the tests: [nose](https://nose.readthedocs.io/en/latest/)

--- a/mnemosyne/android/.idea/checkstyle-idea.xml
+++ b/mnemosyne/android/.idea/checkstyle-idea.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA">
+    <option name="configuration">
+      <map>
+        <entry key="checkstyle-version" value="8.42" />
+        <entry key="copy-libs" value="false" />
+        <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
+        <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />
+        <entry key="scan-before-checkin" value="false" />
+        <entry key="scanscope" value="JavaOnly" />
+        <entry key="suppress-errors" value="false" />
+      </map>
+    </option>
+  </component>
+</project>

--- a/mnemosyne/android/.idea/misc.xml
+++ b/mnemosyne/android/.idea/misc.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />
     <option name="myNullables">
       <value>
-        <list size="12">
+        <list size="13">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.Nullable" />
@@ -18,12 +21,13 @@
           <item index="9" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
           <item index="10" class="java.lang.String" itemvalue="android.annotation.Nullable" />
           <item index="11" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
+          <item index="12" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="11">
+        <list size="13">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="edu.umd.cs.findbugs.annotations.NonNull" />
@@ -35,6 +39,8 @@
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
           <item index="9" class="java.lang.String" itemvalue="android.annotation.NonNull" />
           <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
+          <item index="11" class="java.lang.String" itemvalue="lombok.NonNull" />
+          <item index="12" class="java.lang.String" itemvalue="org.eclipse.jdt.annotation.NonNull" />
         </list>
       </value>
     </option>

--- a/mnemosyne/android/.idea/modules.xml
+++ b/mnemosyne/android/.idea/modules.xml
@@ -3,7 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/android.iml" filepath="$PROJECT_DIR$/android.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/android.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/android.app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/mnemosyne.android.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/mnemosyne.android.app.iml" />
     </modules>
   </component>
 </project>

--- a/mnemosyne/android/android.iml
+++ b/mnemosyne/android/android.iml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module external.linked.project.id="android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="CheckStyle-IDEA-Module">
+    <option name="configuration">
+      <map />
+    </option>
+  </component>
   <component name="FacetManager">
     <facet type="java-gradle" name="Java-Gradle">
       <configuration>
@@ -8,7 +13,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" inherit-compiler-output="true">
+  <component name="NewModuleRootManager">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />

--- a/mnemosyne/android/app/src/main/java/org/mnemosyne/MnemosyneActivity.java
+++ b/mnemosyne/android/app/src/main/java/org/mnemosyne/MnemosyneActivity.java
@@ -565,13 +565,20 @@ public class MnemosyneActivity extends AppCompatActivity {
                 final Integer port = port_data.isEmpty() ? new Integer(8512) : new Integer(port_data);
                 final String username = data.getStringExtra("username");
                 final String password = data.getStringExtra("password");
+                final Boolean rememberPassword = data.getBooleanExtra("rememberPassword", true);
 
                 mnemosyneThread.getHandler().post(new Runnable() {
                     public void run() {
                         mnemosyneThread.bridge.config_set_string("server_for_sync_as_client", server);
                         mnemosyneThread.bridge.config_set_integer("port_for_sync_as_client", port);
                         mnemosyneThread.bridge.config_set_string("username_for_sync_as_client", username);
-                        mnemosyneThread.bridge.config_set_string("password_for_sync_as_client", password);
+                        if (rememberPassword) {
+                            mnemosyneThread.bridge.config_set_string("password_for_sync_as_client", password);
+                            mnemosyneThread.bridge.config_set_boolean("remember_password_for_sync_as_client", true);
+                        } else {
+                            mnemosyneThread.bridge.config_set_string("password_for_sync_as_client", "");
+                            mnemosyneThread.bridge.config_set_boolean("remember_password_for_sync_as_client", false);
+                        }
                         mnemosyneThread.bridge.config_save();
                         PowerManager pm = (PowerManager) getSystemService(Context.POWER_SERVICE);
                         PowerManager.WakeLock wl = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "Mnemosyne:wakelocktag");

--- a/mnemosyne/android/app/src/main/java/org/mnemosyne/MnemosyneBridge.java
+++ b/mnemosyne/android/app/src/main/java/org/mnemosyne/MnemosyneBridge.java
@@ -105,6 +105,18 @@ public class MnemosyneBridge {
         }
     }
 
+    public void config_set_boolean(String key, Boolean value) {
+        try {
+            JSONObject json = new JSONObject();
+            json.put("function", "config_set");
+            json.put("key", key);
+            json.put("value", value);
+            JSONObject result = PyBridge.call(json);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
     public void config_save() {
         try {
             JSONObject json = new JSONObject();

--- a/mnemosyne/android/app/src/main/java/org/mnemosyne/MnemosyneThread.java
+++ b/mnemosyne/android/app/src/main/java/org/mnemosyne/MnemosyneThread.java
@@ -14,8 +14,6 @@ import androidx.documentfile.provider.DocumentFile;
 
 import android.util.Log;
 
-import org.w3c.dom.Document;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -384,6 +382,7 @@ public class MnemosyneThread extends Thread {
         final String port = bridge.config_get("port_for_sync_as_client");
         final String username = bridge.config_get("username_for_sync_as_client");
         final String password = bridge.config_get("password_for_sync_as_client");
+        final Boolean rememberPassword = Boolean.valueOf(bridge.config_get("remember_password_for_sync_as_client"));
 
         UIHandler.post(new Runnable() {
             public void run() {
@@ -392,6 +391,7 @@ public class MnemosyneThread extends Thread {
                 startSyncActivity.putExtra("port", port);
                 startSyncActivity.putExtra("username", username);
                 startSyncActivity.putExtra("password", password);
+                startSyncActivity.putExtra("rememberPassword", rememberPassword);
                 UIActivity.startActivityForResult(startSyncActivity, UIActivity.SYNC_ACTIVITY_RESULT);
             }
         });

--- a/mnemosyne/android/app/src/main/java/org/mnemosyne/SyncActivity.java
+++ b/mnemosyne/android/app/src/main/java/org/mnemosyne/SyncActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
+import android.widget.CheckBox;
 import android.widget.EditText;
 
 
@@ -20,16 +21,19 @@ public class SyncActivity extends Activity {
         String port = getIntent().getStringExtra("port");
         String username = getIntent().getStringExtra("username");
         String password = getIntent().getStringExtra("password");
+        boolean rememberPassword = getIntent().getBooleanExtra("rememberPassword", true);
 
         final EditText editServer = (EditText) findViewById(R.id.editServer);
         final EditText editPort = (EditText) findViewById(R.id.editPort);
         final EditText editUsername = (EditText) findViewById(R.id.editUsername);
         final EditText editPassword = (EditText) findViewById(R.id.editPassword);
+        final CheckBox checkRememberPassword = (CheckBox) findViewById(R.id.checkRememberPassword);
 
         editServer.setText(server);
         editPort.setText(port);
         editUsername.setText(username);
         editPassword.setText(password);
+        checkRememberPassword.setChecked(rememberPassword);
 
         Button button = (Button) findViewById(R.id.syncButton);
 
@@ -41,6 +45,7 @@ public class SyncActivity extends Activity {
                 intent.putExtra("port", editPort.getText().toString().trim());
                 intent.putExtra("username", editUsername.getText().toString().trim());
                 intent.putExtra("password", editPassword.getText().toString().trim());
+                intent.putExtra("rememberPassword", checkRememberPassword.isChecked());
                 setResult(RESULT_OK, intent);
                 finish();
             }

--- a/mnemosyne/android/app/src/main/res/layout/sync.xml
+++ b/mnemosyne/android/app/src/main/res/layout/sync.xml
@@ -59,11 +59,17 @@
          android:ems="10"
          android:inputType="textPassword" />
 
+     <CheckBox
+         android:id="@+id/checkRememberPassword"
+         android:layout_width="match_parent"
+         android:layout_height="wrap_content"
+         android:text="Remember password in plaintext on this device" />
+
      <Button
          android:id="@+id/syncButton"
          android:layout_width="match_parent"
          android:layout_height="wrap_content"
          android:text="Sync" />
-    
- </LinearLayout>    
+
+ </LinearLayout>
 

--- a/mnemosyne/android_python/configuration.py
+++ b/mnemosyne/android_python/configuration.py
@@ -17,5 +17,6 @@ class AndroidConfiguration(Hook):
              "port_for_sync_as_client": 8512,
              "username_for_sync_as_client": "",
              "password_for_sync_as_client": "",
+             "remember_password_for_sync_as_client": True,
             }.items()):
             self.config().setdefault(key, value)

--- a/mnemosyne/libmnemosyne/configuration.py
+++ b/mnemosyne/libmnemosyne/configuration.py
@@ -164,6 +164,7 @@ class Configuration(Component, dict):
              "web_server_port": 8513,
              "remote_access_username": "",
              "remote_access_password": "",
+             "remote_access_password_algo": "",
              "warned_about_learning_ahead": False,
              "shown_backlog_help": False,
              "shown_learn_new_cards_help": False,
@@ -201,6 +202,19 @@ class Configuration(Component, dict):
                 self["user_id"] = rand_uuid()
             else:
                 self["user_id"] = history_files[0].split("_", 1)[0]
+        # Hash the remote access passwords if it was previously stored in plain
+        # text by an older version of mnemosyne.
+        if self["remote_access_password"] != "" and \
+                self["remote_access_password_algo"] == "":
+            from argon2 import PasswordHasher
+            from argon2.exceptions import HashingError
+            try:
+                ph = PasswordHasher()
+                self["remote_access_password"] = \
+                    ph.hash(self["remote_access_password"])
+                self["remote_access_password_algo"] = "argon2"
+            except HashingError:
+                pass
         self["latex"] = self["latex"].strip().split()
         self["dvipng"] = self["dvipng"].strip().split()
         # Allow other plugins or frontend to set their configuration data.

--- a/mnemosyne/pyqt_ui/configuration.py
+++ b/mnemosyne/pyqt_ui/configuration.py
@@ -47,6 +47,7 @@ class PyQtConfiguration(Hook):
              "port_for_sync_as_client": 8512,
              "username_for_sync_as_client": "",
              "password_for_sync_as_client": "",
+             "remember_password_for_sync_as_client": True,
              "started_add_edit_cards_n_times": 0,
              "started_browse_cards_n_times": 0,
              "started_activate_cards_n_times": 0,

--- a/mnemosyne/pyqt_ui/configuration_wdgt_servers.py
+++ b/mnemosyne/pyqt_ui/configuration_wdgt_servers.py
@@ -4,6 +4,8 @@
 
 import socket
 import http.client
+from argon2 import PasswordHasher
+from argon2.exceptions import HashingError
 from PyQt5 import QtGui, QtWidgets
 
 from mnemosyne.libmnemosyne.gui_translator import _
@@ -29,7 +31,11 @@ class ConfigurationWdgtServers(QtWidgets.QWidget, ConfigurationWidget,
         self.run_sync_server.setChecked(self.config()["run_sync_server"])
         self.sync_port.setValue(sync_port)
         self.username.setText(self.config()["remote_access_username"])
-        self.password.setText(self.config()["remote_access_password"])
+        if self.config()["remote_access_password_algo"] == "":
+            self.password.setText(self.config()["remote_access_password"])
+        else:
+            self.password_stacked_widget.setCurrentWidget(
+                self.reset_password_page)
         self.check_for_edited_local_media_files.setChecked(\
             self.config()["check_for_edited_local_media_files"])
         self.run_web_server.setChecked(self.config()["run_web_server"])
@@ -58,6 +64,9 @@ class ConfigurationWdgtServers(QtWidgets.QWidget, ConfigurationWidget,
             socket.setdefaulttimeout(timeout)
             return False
 
+    def reset_password(self):
+        self.password_stacked_widget.setCurrentWidget(self.edit_password_page)
+
     def reset_to_defaults(self):
         answer = self.main_widget().show_question(\
             _("Reset current tab to defaults?"), _("&Yes"), _("&No"), "")
@@ -66,6 +75,7 @@ class ConfigurationWdgtServers(QtWidgets.QWidget, ConfigurationWidget,
         self.run_sync_server.setChecked(False)
         self.sync_port.setValue(8512)
         self.username.setText("")
+        self.password_stacked_widget.setCurrentWidget(self.edit_password_page)
         self.password.setText("")
         self.check_for_edited_local_media_files.setChecked(False)
         self.web_port.setValue(8513)
@@ -74,7 +84,21 @@ class ConfigurationWdgtServers(QtWidgets.QWidget, ConfigurationWidget,
         self.config()["run_sync_server"] = self.run_sync_server.isChecked()
         self.config()["sync_server_port"] = self.sync_port.value()
         self.config()["remote_access_username"] = self.username.text()
-        self.config()["remote_access_password"] = self.password.text()
+        if self.password_stacked_widget.currentWidget() == \
+                self.edit_password_page:
+            if self.password.text() == "":
+                self.config()["remote_access_password"] = ""
+                self.config()["remote_access_password_algo"] = ""
+            else:
+                try:
+                    ph = PasswordHasher()
+                    self.config()["remote_access_password"] = \
+                        ph.hash(self.password.text())
+                    self.config()["remote_access_password_algo"] = "argon2"
+                except HashingError as e:
+                    self.main_widget().show_error(
+                        _("An error occurred while creating the password hash "
+                          "(“%s”). The password was not updated.") % str(e))
         self.config()["check_for_edited_local_media_files"] = \
             self.check_for_edited_local_media_files.isChecked()
         self.config()["run_web_server"] = self.run_web_server.isChecked()

--- a/mnemosyne/pyqt_ui/configuration_wdgt_servers.ui
+++ b/mnemosyne/pyqt_ui/configuration_wdgt_servers.ui
@@ -45,10 +45,53 @@
            </widget>
           </item>
           <item row="1" column="1" colspan="2">
-           <widget class="QLineEdit" name="password">
-            <property name="echoMode">
-             <enum>QLineEdit::Password</enum>
-            </property>
+           <widget class="QStackedWidget" name="password_stacked_widget">
+            <widget class="QWidget" name="edit_password_page">
+             <layout class="QGridLayout" name="gridLayout_2">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QLineEdit" name="password">
+                <property name="echoMode">
+                 <enum>QLineEdit::Password</enum>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="reset_password_page">
+             <layout class="QGridLayout" name="gridLayout_3">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="0" column="0">
+               <widget class="QPushButton" name="reset_password_button">
+                <property name="text">
+                 <string>Reset password</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </widget>
            </widget>
           </item>
           <item row="2" column="0">
@@ -171,5 +214,25 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>reset_password_button</sender>
+   <signal>clicked()</signal>
+   <receiver>ConfigurationWdgtServers</receiver>
+   <slot>reset_password()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>324</x>
+     <y>101</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>288</x>
+     <y>180</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>reset_password()</slot>
+ </slots>
 </ui>

--- a/mnemosyne/pyqt_ui/sync_dlg.py
+++ b/mnemosyne/pyqt_ui/sync_dlg.py
@@ -134,6 +134,8 @@ class SyncDlg(QtWidgets.QDialog, SyncDialog, Ui_SyncDlg):
         self.port.setValue(self.config()["port_for_sync_as_client"])
         self.username.setText(self.config()["username_for_sync_as_client"])
         self.password.setText(self.config()["password_for_sync_as_client"])
+        self.remember_password.setChecked(
+            self.config()["remember_password_for_sync_as_client"])
         self.check_for_edited_local_media_files.setChecked(\
             self.config()["check_for_edited_local_media_files"])
         if self.config()["server_for_sync_as_client"]:
@@ -162,7 +164,12 @@ class SyncDlg(QtWidgets.QDialog, SyncDialog, Ui_SyncDlg):
         self.config()["server_for_sync_as_client"] = server
         self.config()["port_for_sync_as_client"] = port
         self.config()["username_for_sync_as_client"] = username
-        self.config()["password_for_sync_as_client"] = password
+        if self.remember_password.isChecked():
+            self.config()["password_for_sync_as_client"] = password
+            self.config()["remember_password_for_sync_as_client"] = True
+        else:
+            self.config()["password_for_sync_as_client"] = ""
+            self.config()["remember_password_for_sync_as_client"] = False
         self.config()["check_for_edited_local_media_files"] = \
             self.check_for_edited_local_media_files.isChecked()
         self._store_state()

--- a/mnemosyne/pyqt_ui/sync_dlg.ui
+++ b/mnemosyne/pyqt_ui/sync_dlg.ui
@@ -82,6 +82,13 @@
       </layout>
      </item>
      <item>
+      <widget class="QCheckBox" name="remember_password">
+       <property name="text">
+        <string>Remember password in plaintext on this device</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QCheckBox" name="check_for_edited_local_media_files">
        <property name="text">
         <string>Check for changed media files on client</string>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+argon2-cffi
 cheroot
 cherrypy
 matplotlib


### PR DESCRIPTION
This PR contains two (relatively) small changes to avoid storing passwords in plaintext in the sync mechanism:

- On the server side, only a hash value of the password will be stored. I was actually quite shocked to learn that Mnemosyne didn’t do this already. The password hashing algorithms recommended most often these days are Argon2, bcrypt and scrypt<sup>[Citation needed]</sup>, but unfortunately none of them are universally available in the Python standard library, so I used the fairly lightweight argon2-cffi library to implement hashing using Argon2. I wrote the code in such a way that the library is only required for frontends that actually make use of the sync server (e.g. the Android frontend does not require the library). Pre-existing plaintext passwords will be hashed automatically when the configuration is loaded or, if that fails, when the user logs in. If a hashed password exists, the config dialog will now initially show a reset button instead of the line edit.
- On the client side, I made the password remembering feature optional and clarified that it will in fact store the password in plaintext (unlike, for example, token-based mechanisms).

(I noticed that a bunch of files in the .idea folder got modified. Since I didn’t change anything manually, I assumed it must have been because of a newer IDE version or something and committed them, let me know if it’s a problem.)