### PR TITLE
Added "PyQtWebEngine" to the pip install/upgrade command.

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ Install the following dependencies if needed:
 
 These can be installed/upgraded using pip:
 
-pip install --upgrade PyQt5 matplotlib cheroot webob pillow googletrans gTTS
+pip install --upgrade PyQt5 PyQtWebEngine matplotlib cheroot webob pillow googletrans gTTS
 
 Install Mnemosyne itself with 'sudo python setup.py install'.
 


### PR DESCRIPTION
Mnemosyne would not start after installing it from sources on a fresh install of Python on a Fedora 34 distro.
Installing "PyQtWebEngine" solved the issue.