### PR TITLE
add .webp to insert_img() filter as PIL now supports webp

### DIFF
--- a/mnemosyne/pyqt_ui/qtextedit2.py
+++ b/mnemosyne/pyqt_ui/qtextedit2.py
@@ -109,8 +109,8 @@ class QTextEdit2(QtWidgets.QTextEdit):
             QtWidgets.QTextEdit.keyPressEvent(self, event)
 
     def insert_img(self):
-        filter = "(*.png *.gif *.jpg *.bmp *.jpeg *.svg *.tiff" + \
-                 " *.PNG *.GIF *.jpg *.BMP *.JPEG *.SVG *.TIFF)"
+        filter = "(*.png *.gif *.jpg *.bmp *.jpeg *.svg *.tiff" *.webp + \
+                 " *.PNG *.GIF *.jpg *.BMP *.JPEG *.SVG *.TIFF *.WEBP)"
         filename = self.parent().controller().show_insert_img_dialog(filter)
         if filename:
             self.insertPlainText("<img src=\"" + filename + "\">")


### PR DESCRIPTION
Hello~ the python3 pillow module now supports .webp format so I would like to update the filename filters to include .webp

I tested this on Ubuntu 20.04.3 LTS where Python 3.8.10 is the default python 3 version and inserting .webp images into Mnemosyne cards is working fine. I am replacing the animated .gif files in my mnemosyne cards with animated .webp files which are about 40% smaller!