### PR TITLE
add warnings for missing gtts and google_trans

### DIFF
--- a/mnemosyne/libmnemosyne/__init__.py
+++ b/mnemosyne/libmnemosyne/__init__.py
@@ -6,6 +6,7 @@ import os
 import sys
 import importlib
 import traceback
+import warnings
 from mnemosyne.libmnemosyne.component import Component
 from mnemosyne.libmnemosyne.utils import expand_path, contract_path, \
     traceback_string
@@ -364,10 +365,14 @@ class Mnemosyne(Component):
           "Zulu")]
         if (importlib.util.find_spec("gtts")) is not None:
             self.components.append(("mnemosyne.libmnemosyne.pronouncers.google_pronouncer",
-                                   "GooglePronouncer")),
+                                    "GooglePronouncer"))
+        else:
+            warnings.warn("gTTS package is not installed. Text to speak feature will not be available ")
         if ((importlib.util.find_spec("google_trans_new")) is not None) and ((importlib.util.find_spec("googletrans")) is not None):
             self.components.append(("mnemosyne.libmnemosyne.translators.google_translator",
-                                    "GoogleTranslator")),
+                                    "GoogleTranslator"))
+        else:
+            warnings.warn("google_trans and google_trans_new packages are not installed. Google translate feature will not be available ")
         self.gui_for_component = {}
 
     def handle_exception(self, type, value, tb):


### PR DESCRIPTION
see https://github.com/mnemosyne-proj/mnemosyne/issues/200#issuecomment-916293360

sadly the warnings get printed twice:
```
/home/lukas/git/mnemosyne/mnemosyne/libmnemosyne/__init__.py:370: UserWarning: gTTS package is not installed. Text to speak feature will not be available 
  warnings.warn("gTTS package is not installed. Text to speak feature will not be available ")
```