### PR TITLE
Avoid infinite error loop when converting a card to cloze type

### DIFF
--- a/mnemosyne/libmnemosyne/renderers/anki_renderer.py
+++ b/mnemosyne/libmnemosyne/renderers/anki_renderer.py
@@ -19,7 +19,7 @@ class AnkiRenderer(Renderer):
     def render(self, card, filtered_fact_data, render_chain, **render_args):
         card_type = card.card_type
         extra_data = card.fact_view.extra_data
-        extra_data["ord"] = card.extra_data["ord"]
+        extra_data["ord"] = card.extra_data.get("ord", 0)
         fields = {}
         for fact_key, fact_key_name in card_type.fact_keys_and_names:
             fields[fact_key_name] = filtered_fact_data.get(fact_key, "")


### PR DESCRIPTION
I'm not sure exactly why this happened, but I tried changing a front-to-back card to the "Cloze" card type. When I restarted Mnemosyne and opened the card browser, it went into an infinite loop complaining that the field `ord` of the card's `extra_data` dict was missing.
Using a default value of the empty string also results in an infinite error loop, since some arithmetic is performed on the value later. I'm not sure where the "ord" field is supposed to come from, so for now I set it to a default value of `0` but that produces empty output in the card preview. It does stop the infinite error though.