### PR TITLE
Added pyqtwebengine to fix build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ matplotlib
 webob
 sphinx
 pyqt5
+pyqtwebengine
 nose
 decorator


### PR DESCRIPTION
Checking out `41fd12ab731ef323502c0209665917ac8ec13763` and building in a venv by doing the following:

```
pip install -r requirements.txt
make build-all-deps
make
```

Would fail on `make` with the error:


```
Traceback (innermost last):
  File "/home/hgrahamcs/workspace/mnemosyne/mnemosyne/pyqt_ui/mnemosyne", line 150, in <module>
    from PyQt5 import QtWebEngineWidgets  # Needs to happen first for some reason.
 ImportError: cannot import name 'QtWebEngineWidgets' from 'PyQt5' (/home/hgrahamcs/workspace/mnemosyne/venv/lib64/python3.10/site-packages/PyQt5/__init__.py)
make: *** [makefile:32: run] Error 1
```

To resolve this error I had to add `pyqtwebengine` to the requirements.txt file.