### PR TITLE
Fix TypeError on Study->(De)activate cards...

### DIFF
--- a/mnemosyne/pyqt_ui/activate_cards_dlg.py
+++ b/mnemosyne/pyqt_ui/activate_cards_dlg.py
@@ -98,8 +98,8 @@ class ActivateCardsDlg(QtWidgets.QDialog, ActivateCardsDialog,
             self.splitter.setSizes([0, sum(splitter_sizes)])
         else:
             if splitter_sizes[0] == 0: # First time we add a set.
-                self.splitter.setSizes([0.3* sum(splitter_sizes),
-                    0.7 * sum(splitter_sizes)])
+                self.splitter.setSizes([int(0.3* sum(splitter_sizes)),
+                    int(0.7 * sum(splitter_sizes))])
 
     def saved_sets_custom_menu(self, pos):
         menu = QtWidgets.QMenu()


### PR DESCRIPTION
fixes a TypeError that happend on "Study->(De)activate cards..." when
there was (at least) one saved set with the message:

An unexpected error has occurred.
Please forward the following info to the developers:

Traceback (innermost last):
  File "/usr/lib/python3/dist-packages/mnemosyne/pyqt_ui/main_wdgt.py", line 246, in activate_cards
    self.controller().show_activate_cards_dialog()
  File "/usr/lib/python3/dist-packages/mnemosyne/libmnemosyne/controllers/default_controller.py", line 851, in show_activate_cards_dialog
    self.show_activate_cards_dialog_pre()
  File "/usr/lib/python3/dist-packages/mnemosyne/libmnemosyne/controllers/default_controller.py", line 857, in show_activate_cards_dialog_pre
    self.component_manager.current("activate_cards_dialog")\
  File "/usr/lib/python3/dist-packages/mnemosyne/pyqt_ui/activate_cards_dlg.py", line 61, in __init__
    self.update_saved_sets_pane()
  File "/usr/lib/python3/dist-packages/mnemosyne/pyqt_ui/activate_cards_dlg.py", line 101, in update_saved_sets_pane
    self.splitter.setSizes([0.3* sum(splitter_sizes),
 TypeError: index 0 has type 'float' but 'int' is expected