### PR TITLE
Make images not grow to maximum size

### DIFF
--- a/mnemosyne/web_server/review_wdgt.py
+++ b/mnemosyne/web_server/review_wdgt.py
@@ -57,7 +57,7 @@ input {
   width: 100%;
 }
 img {
-  width: 100%;
+  max-width: 100%;
 }
 
 $card_css


### PR DESCRIPTION
Resolves the issue mentioned in https://github.com/mnemosyne-proj/mnemosyne/issues/228. Previous images would be resized to always take up the entire screen width, but this had poor results with some small images, like LaTeX. This changes it to shrink images that are wider than the screen but not expand images that are smaller.