### PR TITLE
Initialize combobox with stored variant index in statistics widget

### DIFF
--- a/mnemosyne/pyqt_ui/statistics_dlg.py
+++ b/mnemosyne/pyqt_ui/statistics_dlg.py
@@ -73,6 +73,7 @@ class StatisticsDlg(QtWidgets.QDialog, StatisticsDialog, Ui_StatisticsDlg):
             ["previous_variant_for_statistics_page"][page_index]
         if variant_index >= page.combobox.count():
             variant_index = 0
+        page.combobox.setCurrentIndex(variant_index)
         page.display_variant(variant_index)
 
 


### PR DESCRIPTION
The combobox on a statistics page wasn't set to the correct index when the last shown variant of that page wasn't the first one in the list of combobox items.

Steps to reproduce:
1) Open the statistics widget and choose a variant which isn't the first one in the combobox list.
2) Close and reopen the statistics widget.

Expected result: The chart and combobox text will show the variant that was displayed before the widget was closed.

Actual behaviour: The correct chart is shown, but the combobox shows the text for the first item in the list.