### PR TITLE
Enrich InnoSetup info for Windows installer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,13 @@ class InnoScript:
         print(r"[Setup]", file=ofi)
         print(r"AppName=%s" % self.name, file=ofi)
         print(r"AppVerName=%s %s" % (self.name, self.version), file=ofi)
+        print(r"AppVersion=%s" % self.version, file=ofi)
         print(r"DefaultDirName={pf}\%s" % self.name, file=ofi)
         print(r"DefaultGroupName=%s" % self.name, file=ofi)
+        publisher = "Peter Bienstman"
+        print(r"AppPublisher=%s" % publisher, file=ofi)
+        path = "mnemosyne.exe"
+        print(r"UninstallDisplayIcon={app}\%s" % path, file=ofi)
         print(file=ofi)
         print(r"[Messages]", file=ofi)
         print(r"ConfirmUninstall=Are you really really sure you want to remove %1? Your cards will not be deleted.", file=ofi)


### PR DESCRIPTION
Fill some directive values to InnoSetup script to help Windows better display the app information.

For example, in Windows 11 settings "Installed apps" page, Mnemosyne only show its name with version in it, without publisher information and custom icon.
![Screenshot 2024-05-20 235304](https://github.com/mnemosyne-proj/mnemosyne/assets/1892221/e5748da4-e3e7-4fda-8185-0e7cb7fceea5)

Compared with other app like InnoSetup itself:
![image](https://github.com/mnemosyne-proj/mnemosyne/assets/1892221/1f64d126-08d7-427a-8212-042fd00055d7)

Also, other app management software like WinGet also fails to determine the installed Mnemosyne's version:
![image](https://github.com/mnemosyne-proj/mnemosyne/assets/1892221/79603aee-4acf-478b-ba3d-62e8c542d3a1)