### PR TITLE
pyqt_ui: quit application when receiving ctrl-q

### DIFF
--- a/mnemosyne/pyqt_ui/main_wdgt.py
+++ b/mnemosyne/pyqt_ui/main_wdgt.py
@@ -38,6 +38,13 @@ class MainWdgt(QtWidgets.QMainWindow, MainWidget, Ui_MainWdgt):
         # Don't create a silly popup menu saying ('toolBar').
         pass
 
+    def keyPressEvent(self, event):
+        if event.key() == QtCore.Qt.Key.Key_Q and \
+            event.modifiers() == QtCore.Qt.KeyboardModifier.ControlModifier:
+            self.close()
+        else:
+            QtWidgets.QMainWindow.keyPressEvent(self, event)
+
     def closeEvent(self, event):
         # Generated when clicking the window's close button.
         self._store_state()


### PR DESCRIPTION
Fixes #290. Handle a Ctrl-Q keypress that reaches the main widget by closing the application. Note that this means that the Ctrl-Q quit isn't active when dialogs are open, which I think is the right behavior.