### PR TITLE
pyqt_ui: Quit using Ctrl-Q using the .ui file rather than code

### DIFF
--- a/mnemosyne/pyqt_ui/main_wdgt.py
+++ b/mnemosyne/pyqt_ui/main_wdgt.py
@@ -38,13 +38,6 @@ class MainWdgt(QtWidgets.QMainWindow, MainWidget, Ui_MainWdgt):
         # Don't create a silly popup menu saying ('toolBar').
         pass
 
-    def keyPressEvent(self, event):
-        if event.key() == QtCore.Qt.Key.Key_Q and \
-            event.modifiers() == QtCore.Qt.KeyboardModifier.ControlModifier:
-            self.close()
-        else:
-            QtWidgets.QMainWindow.keyPressEvent(self, event)
-
     def closeEvent(self, event):
         # Generated when clicking the window's close button.
         self._store_state()

--- a/mnemosyne/pyqt_ui/main_wdgt.ui
+++ b/mnemosyne/pyqt_ui/main_wdgt.ui
@@ -207,6 +207,9 @@
    <property name="text">
     <string>E&amp;xit</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
   </action>
   <action name="actionFileNew">
    <property name="icon">


### PR DESCRIPTION
I realized that this is a better way to make the change, and it displays the keybinding in the UI which is much more discoverable.

Follow up to #291