### PR TITLE
Fix startup failure due to missing files in wheels built directly from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,9 @@ authors = ["Peter Bienstman <Peter.Bienstman@gmail.com>"]
 readme = "README.md"
 packages = [{include = "mnemosyne"},
             {include = "openSM2sync"}]
-include = ["mnemosyne/pyqt_ui/ui_*", "makefile", "pixmaps/*",
-    "tests/*", "mnemosyne/pyqt_ui/makefile"]
+include = [{path = "mnemosyne/pyqt_ui/ui_*", format = ["sdist", "wheel"]},
+    "makefile", {path = "pixmaps/*", format = ["sdist", "wheel"]}, "tests/*",
+    "mnemosyne/pyqt_ui/makefile"]
 exclude = ["mnemosyne/android", "mnemosyne/android_python", 
     "mnemosyne/embedded_in_C", "mnemosyne/UDP_server"]
 


### PR DESCRIPTION
This fixes an issue where the ui_*.py files are missing from the wheel if the wheel is built from the original source rather than the from the sdist. To understand why this happens and why it seemingly hasn’t been noticed before, first recall that:

- by default, excludes in pyproject.toml apply to both sdists and wheels, whereas includes apply only to sdists unless specified otherwise
- excludes is automatically populated with any files listed in .gitignore (if git is available)
- the default behaviour of `python -m build` is to first creates an sdist, then create the wheel from that sdist (rather than from the original source)

Because the sdist does not contain the .gitignore file, when a wheel is created from it the ui files are included by default. The fact that by defaut the includes setting does not apply to wheels therefore does not matter as far as the ui files in the wheel are concerned.

However, when the wheel is generated from the original source via the `--wheel` flag, the .gitignore contents are taken into account and therefore the ui files are excluded from the wheel. The includes setting, which does list the ui files, is ineffective because it only applies to sdists, not wheels. Therefore, the resulting wheel ends up without the ui files and Mnemosyne fails to start with "ModuleNotFoundError: No module named 'mnemosyne.pyqt_ui.ui_main_wdgt'".

To fix this, this PR updates the includes entry for the ui files to apply to both sdists and wheels. For completeness’ sake, I’ve applied the same treatment to the pixmaps entry as well. (On that note, there appears to be some redundancy between /pixmaps and /mnemosyne/pyqt_ui/pixmaps, I wonder if that is intended)

(It took me a while to figure this out myself – I hope I managed to convey what issue I’m trying to fix, but if you need more clarification, please do let me know.)