### PR TITLE
Fix desktop file name warning

### DIFF
--- a/mnemosyne/pyqt_ui/mnemosyne
+++ b/mnemosyne/pyqt_ui/mnemosyne
@@ -165,7 +165,7 @@ if options.qt_opengl:
 
 a = QApplication(sys.argv)
 a.setApplicationName("Mnemosyne")
-a.setDesktopFileName("mnemosyne.desktop")
+a.setDesktopFileName("mnemosyne")
 #a.setStyle(QStyleFactory.create("fusion"))
 
 # Get rid of the white menubar on Windows and do some further tweaks.


### PR DESCRIPTION
This fixes the following runtime warning introduced in Qt 6.5.2:

    QGuiApplication::setDesktopFileName: the specified desktop file name ends with .desktop. For compatibility reasons, the .desktop suffix will be removed. Please specify a desktop file name without .desktop suffix